### PR TITLE
"use strict" must go inside the function to allow for concatenation.

### DIFF
--- a/console-shim.js
+++ b/console-shim.js
@@ -6,9 +6,9 @@
  * (See http://www.opensource.org/licenses/mit-license)
  */
  
-'use strict';
  
 (function(){
+'use strict';
 
 /**
  * Returns a function which calls the specified function in the specified


### PR DESCRIPTION
"use strict" must go inside the function to allow for concatenation.
